### PR TITLE
Fix inconsistent deal property names

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -61,7 +61,7 @@ async def upload(files: list[UploadFile] = File(...)):
     for file in files:
         raw_text = extract_text(file)
         fields = extract_fields(raw_text)
-        fields["aiInsights"] = generate_insight(raw_text)
+        fields["ai_insights"] = generate_insight(raw_text)
         deal = Deal(**fields)
         db.add(deal)
         db.commit()

--- a/frontend/src/DealIntelligenceApp.tsx
+++ b/frontend/src/DealIntelligenceApp.tsx
@@ -54,7 +54,7 @@ export default function DealIntelligenceApp() {
                       <TableCell>{deal.revenue}</TableCell>
                       <TableCell>{deal.ebitda}</TableCell>
                       <TableCell>{deal.margin}</TableCell>
-                      <TableCell>{deal.capitalSought}</TableCell>
+                      <TableCell>{deal.capital_sought}</TableCell>
                       <TableCell>{deal.objective}</TableCell>
                     </TableRow>
                   ))}
@@ -75,7 +75,7 @@ export default function DealIntelligenceApp() {
                       <li key={i}>{h}</li>
                     ))}
                   </ul>
-                  <p><strong>AI Insights:</strong> {selectedDeal.aiInsights}</p>
+                  <p><strong>AI Insights:</strong> {selectedDeal.ai_insights}</p>
                   <Button variant="outline" onClick={() => alert('Deep research view coming soon...')}>Explore More</Button>
                 </CardContent>
               </Card>


### PR DESCRIPTION
## Summary
- use `ai_insights` when creating `Deal` records
- update React components to read underscore API fields

## Testing
- `npm test --prefix frontend` *(fails: Missing script & no internet)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68543a6fb1c4832dae1e87d48c2e34a7