### PR TITLE
Add React app entrypoint

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Deal Insights</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,9 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import DealIntelligenceApp from './DealIntelligenceApp';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <DealIntelligenceApp />
+  </React.StrictMode>
+);


### PR DESCRIPTION
## Summary
- provide an `index.html` for Vite to serve
- add a `main.tsx` entry that mounts `DealIntelligenceApp`

## Testing
- `npm run dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68543bfb7944832dbc76bf18b65cda74