### PR TITLE
Add ShadCN-style UI components

### DIFF
--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+
+function cn(...classes: (string | undefined)[]) {
+  return classes.filter(Boolean).join(" ");
+}
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, ...props }, ref) => (
+    <button
+      ref={ref}
+      className={cn(
+        "inline-flex items-center justify-center rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 focus:outline-none",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Button.displayName = "Button";
+
+export default Button;

--- a/frontend/src/components/ui/card.tsx
+++ b/frontend/src/components/ui/card.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+
+function cn(...classes: (string | undefined)[]) {
+  return classes.filter(Boolean).join(" ");
+}
+
+export interface CardProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const Card = React.forwardRef<HTMLDivElement, CardProps>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        "rounded-lg border bg-white text-black shadow",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Card.displayName = "Card";
+
+export interface CardContentProps extends React.HTMLAttributes<HTMLDivElement> {}
+
+export const CardContent = React.forwardRef<HTMLDivElement, CardContentProps>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("p-6", className)} {...props} />
+  )
+);
+CardContent.displayName = "CardContent";
+
+export default Card;

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,0 +1,24 @@
+import * as React from "react";
+
+function cn(...classes: (string | undefined)[]) {
+  return classes.filter(Boolean).join(" ");
+}
+
+export interface InputProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {}
+
+export const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, ...props }, ref) => (
+    <input
+      ref={ref}
+      className={cn(
+        "flex h-10 w-full rounded-md border px-3 py-2 text-sm focus:outline-none",
+        className
+      )}
+      {...props}
+    />
+  )
+);
+Input.displayName = "Input";
+
+export default Input;

--- a/frontend/src/components/ui/table.tsx
+++ b/frontend/src/components/ui/table.tsx
@@ -1,0 +1,58 @@
+import * as React from "react";
+
+function cn(...classes: (string | undefined)[]) {
+  return classes.filter(Boolean).join(" ");
+}
+
+export interface TableProps extends React.HTMLAttributes<HTMLTableElement> {}
+export function Table({ className, ...props }: TableProps) {
+  return (
+    <table className={cn("w-full text-sm caption-bottom", className)} {...props} />
+  );
+}
+
+export interface TableHeaderProps
+  extends React.HTMLAttributes<HTMLTableSectionElement> {}
+export function TableHeader({ className, ...props }: TableHeaderProps) {
+  return <thead className={cn("[&_tr]:border-b", className)} {...props} />;
+}
+
+export interface TableBodyProps
+  extends React.HTMLAttributes<HTMLTableSectionElement> {}
+export function TableBody({ className, ...props }: TableBodyProps) {
+  return <tbody className={className} {...props} />;
+}
+
+export interface TableRowProps
+  extends React.HTMLAttributes<HTMLTableRowElement> {}
+export function TableRow({ className, ...props }: TableRowProps) {
+  return (
+    <tr
+      className={cn(
+        "border-b transition-colors hover:bg-gray-50",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export interface TableHeadProps
+  extends React.ThHTMLAttributes<HTMLTableCellElement> {}
+export function TableHead({ className, ...props }: TableHeadProps) {
+  return (
+    <th
+      className={cn(
+        "h-10 px-2 text-left align-middle font-medium text-gray-500",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+export interface TableCellProps
+  extends React.TdHTMLAttributes<HTMLTableCellElement> {}
+export function TableCell({ className, ...props }: TableCellProps) {
+  return <td className={cn("p-2 align-middle", className)} {...props} />;
+}

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -1,0 +1,60 @@
+import * as React from "react";
+
+function cn(...classes: (string | undefined)[]) {
+  return classes.filter(Boolean).join(" ");
+}
+
+interface TabsContextValue {
+  value: string;
+  setValue: (value: string) => void;
+}
+
+const TabsContext = React.createContext<TabsContextValue | null>(null);
+
+export interface TabsProps extends React.HTMLAttributes<HTMLDivElement> {
+  defaultValue: string;
+}
+
+export function Tabs({ defaultValue, className, children }: TabsProps) {
+  const [value, setValue] = React.useState(defaultValue);
+  return (
+    <TabsContext.Provider value={{ value, setValue }}>
+      <div className={className}>{children}</div>
+    </TabsContext.Provider>
+  );
+}
+
+export interface TabsListProps extends React.HTMLAttributes<HTMLDivElement> {}
+export function TabsList({ className, ...props }: TabsListProps) {
+  return <div className={cn("flex gap-2", className)} {...props} />;
+}
+
+export interface TabsTriggerProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  value: string;
+}
+export function TabsTrigger({ value, className, ...props }: TabsTriggerProps) {
+  const context = React.useContext(TabsContext);
+  if (!context) return null;
+  const active = context.value === value;
+  return (
+    <button
+      className={cn(
+        "px-3 py-1 rounded border",
+        active ? "bg-blue-600 text-white" : "bg-white",
+        className
+      )}
+      onClick={() => context.setValue(value)}
+      {...props}
+    />
+  );
+}
+
+export interface TabsContentProps extends React.HTMLAttributes<HTMLDivElement> {
+  value: string;
+}
+export function TabsContent({ value, className, ...props }: TabsContentProps) {
+  const context = React.useContext(TabsContext);
+  if (!context || context.value !== value) return null;
+  return <div className={className} {...props} />;
+}


### PR DESCRIPTION
## Summary
- scaffold basic UI components in `frontend/src/components/ui`
- export Card, Button, Input, Tabs, and Table utilities used by `DealIntelligenceApp`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68543d222024832db48a517ebbf85b32