### PR TITLE
Implement backend data model and insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,18 @@ A full-stack AI-powered deal intelligence platform for private credit investors 
 - Upload teaser PDFs
 - Extract and compare key deal metrics
 - Generate personalized investment memos with LLMs
+- Identify basic comparables and risk indicators
 - Extend with public data enrichment
 
 ## Tech Stack
 - Frontend: React + Tailwind (ShadCN UI)
 - Backend: FastAPI + LangChain + OpenAI
 - Database: PostgreSQL
+
+### Database Schema
+- **deals**: extracted fields, AI insights, comparables and risks
+- **users**: name, mandates and preferred sectors
+- **memos**: AI generated memos linked to deals
 
 ## Setup
 

--- a/backend/db/__init__.py
+++ b/backend/db/__init__.py
@@ -2,7 +2,7 @@ import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
-from .schema import Base, Deal
+from .schema import Base, Deal, User, Memo
 
 DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./deals.db")
 
@@ -12,4 +12,4 @@ SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 # Create tables on import for demo purposes
 Base.metadata.create_all(engine)
 
-__all__ = ["Deal", "SessionLocal"]
+__all__ = ["Deal", "User", "Memo", "SessionLocal"]

--- a/backend/db/schema.py
+++ b/backend/db/schema.py
@@ -1,11 +1,11 @@
-from sqlalchemy import Column, Integer, String, Float, Text
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import Column, Integer, String, Float, Text, ForeignKey
+from sqlalchemy.orm import relationship, declarative_base
 
 Base = declarative_base()
 
 
 class Deal(Base):
-    __tablename__ = 'deals'
+    __tablename__ = "deals"
 
     id = Column(Integer, primary_key=True)
     name = Column(String)
@@ -18,3 +18,26 @@ class Deal(Base):
     summary = Column(Text)
     highlights = Column(Text)
     ai_insights = Column(Text)
+    comparables = Column(Text)
+    risk_indicators = Column(Text)
+
+    memos = relationship("Memo", back_populates="deal")
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String)
+    mandates = Column(Text)
+    sectors = Column(Text)
+
+
+class Memo(Base):
+    __tablename__ = "memos"
+
+    id = Column(Integer, primary_key=True)
+    deal_id = Column(Integer, ForeignKey("deals.id"))
+    content = Column(Text)
+
+    deal = relationship("Deal", back_populates="memos")


### PR DESCRIPTION
## Summary
- extend features list and document database schema
- add comparables and risk indicators to `Deal` model
- create `User` and `Memo` tables
- generate memo, comparables, and risk with LangChain
- persist uploaded deal data and generated memo

## Testing
- `python -m compileall backend`
- `npm run build` *(fails: `vite` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685443340cdc832dbedf3739075c4ca2