### PR TITLE
Fix env loading for backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ A full-stack AI-powered deal intelligence platform for private credit investors 
 
 ## Setup
 
-1. Create a `.env` with your OpenAI key and database URL
+1. Create a `.env` file with your `OPENAI_API_KEY` and optional `DATABASE_URL`.
+   The backend automatically loads this file using `python-dotenv`.
 2. Install Python dependencies:
 ```bash
 pip install -r backend/requirements.txt

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,5 @@
 import os
+from dotenv import load_dotenv
 from fastapi import FastAPI, UploadFile, File
 from fastapi.middleware.cors import CORSMiddleware
 from langchain.chat_models import ChatOpenAI
@@ -7,6 +8,8 @@ import pdfplumber
 import json
 
 from ..db import Deal, Memo, SessionLocal
+
+load_dotenv()
 
 app = FastAPI()
 
@@ -18,7 +21,8 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-llm = ChatOpenAI(model='gpt-4')
+openai_api_key = os.getenv("OPENAI_API_KEY")
+llm = ChatOpenAI(model='gpt-4', openai_api_key=openai_api_key)
 
 
 def extract_text(upload: UploadFile) -> str:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,3 +4,4 @@ sqlalchemy
 pdfplumber
 langchain
 openai
+python-dotenv


### PR DESCRIPTION
## Summary
- load environment variables using python-dotenv
- pass `OPENAI_API_KEY` when creating `ChatOpenAI`
- document env file usage
- add `python-dotenv` to requirements

## Testing
- `pytest -q` *(fails: no tests ran)*
- `pip install -r backend/requirements.txt` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685447c23780832d8d57f73000a6602d