### PR TITLE
Add smart memo endpoint and make tab visible

### DIFF
--- a/frontend/src/DealIntelligenceApp.tsx
+++ b/frontend/src/DealIntelligenceApp.tsx
@@ -9,6 +9,7 @@ export default function DealIntelligenceApp() {
   const [files, setFiles] = useState<FileList | null>(null);
   const [deals, setDeals] = useState<any[]>([]);
   const [selectedDeal, setSelectedDeal] = useState<any | null>(null);
+  const [memo, setMemo] = useState<string>('');
   const [status, setStatus] = useState<string>('');
   const apiUrl = import.meta.env.VITE_API_URL || '/api';
 
@@ -32,6 +33,23 @@ export default function DealIntelligenceApp() {
     }
   }
 
+  async function handleSelectDeal(deal: any) {
+    setSelectedDeal(deal);
+    setMemo('Generating memo...');
+    try {
+      const res = await fetch(`${apiUrl}/deals/${deal.id}/memo`);
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || 'Request failed');
+      }
+      const data = await res.json();
+      setMemo(data.memo);
+    } catch (err) {
+      console.error(err);
+      setMemo('Failed to generate memo');
+    }
+  }
+
   return (
     <div className="p-4 space-y-6">
       <div className="space-y-2">
@@ -40,12 +58,11 @@ export default function DealIntelligenceApp() {
         {status && <p>{status}</p>}
       </div>
 
-      {deals.length > 0 && (
-        <Tabs defaultValue="comparison" className="w-full">
-          <TabsList>
-            <TabsTrigger value="comparison">Compare Deals</TabsTrigger>
-            <TabsTrigger value="memo">Smart Memos</TabsTrigger>
-          </TabsList>
+      <Tabs defaultValue="comparison" className="w-full">
+        <TabsList>
+          <TabsTrigger value="comparison">Compare Deals</TabsTrigger>
+          <TabsTrigger value="memo">Smart Memos</TabsTrigger>
+        </TabsList>
 
           <TabsContent value="comparison">
             <Table>
@@ -61,17 +78,25 @@ export default function DealIntelligenceApp() {
                 </TableRow>
               </TableHeader>
                 <TableBody>
-                  {deals.map((deal, i) => (
-                    <TableRow key={i} onClick={() => setSelectedDeal(deal)} className="cursor-pointer">
-                      <TableCell>{deal.name}</TableCell>
-                      <TableCell>{deal.sector}</TableCell>
-                      <TableCell>{deal.revenue}</TableCell>
-                      <TableCell>{deal.ebitda}</TableCell>
-                      <TableCell>{deal.margin}</TableCell>
-                      <TableCell>{deal.capital_sought}</TableCell>
-                      <TableCell>{deal.objective}</TableCell>
+                  {deals.length === 0 ? (
+                    <TableRow>
+                      <TableCell colSpan={7} className="text-center">
+                        Upload teasers to compare deals.
+                      </TableCell>
                     </TableRow>
-                  ))}
+                  ) : (
+                    deals.map((deal, i) => (
+                      <TableRow key={i} onClick={() => handleSelectDeal(deal)} className="cursor-pointer">
+                        <TableCell>{deal.name}</TableCell>
+                        <TableCell>{deal.sector}</TableCell>
+                        <TableCell>{deal.revenue}</TableCell>
+                        <TableCell>{deal.ebitda}</TableCell>
+                        <TableCell>{deal.margin}</TableCell>
+                        <TableCell>{deal.capital_sought}</TableCell>
+                        <TableCell>{deal.objective}</TableCell>
+                      </TableRow>
+                    ))
+                  )}
                 </TableBody>
             </Table>
           </TabsContent>
@@ -90,19 +115,27 @@ export default function DealIntelligenceApp() {
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {deals.map((deal, i) => (
-                      <TableRow
-                        key={i}
-                        onClick={() => setSelectedDeal(deal)}
-                        className={`cursor-pointer ${selectedDeal === deal ? 'bg-gray-100' : ''}`}
-                      >
-                        <TableCell>{deal.name}</TableCell>
-                        <TableCell>{deal.sector}</TableCell>
-                        <TableCell>{deal.revenue}</TableCell>
-                        <TableCell>{deal.ebitda}</TableCell>
-                        <TableCell>{deal.margin}</TableCell>
+                    {deals.length === 0 ? (
+                      <TableRow>
+                        <TableCell colSpan={5} className="text-center">
+                          Upload teasers to generate memos.
+                        </TableCell>
                       </TableRow>
-                    ))}
+                    ) : (
+                      deals.map((deal, i) => (
+                        <TableRow
+                          key={i}
+                          onClick={() => handleSelectDeal(deal)}
+                          className={`cursor-pointer ${selectedDeal === deal ? 'bg-gray-100' : ''}`}
+                        >
+                          <TableCell>{deal.name}</TableCell>
+                          <TableCell>{deal.sector}</TableCell>
+                          <TableCell>{deal.revenue}</TableCell>
+                          <TableCell>{deal.ebitda}</TableCell>
+                          <TableCell>{deal.margin}</TableCell>
+                        </TableRow>
+                      ))
+                    )}
                   </TableBody>
                 </Table>
               </div>
@@ -119,7 +152,7 @@ export default function DealIntelligenceApp() {
                           <li key={i}>{h}</li>
                         ))}
                       </ul>
-                      <p><strong>AI Insights:</strong> {selectedDeal.ai_insights}</p>
+                      <p><strong>AI Insights:</strong> {memo}</p>
                       <Button
                         variant="outline"
                         onClick={() => alert('Deep research view coming soon...')}
@@ -135,7 +168,6 @@ export default function DealIntelligenceApp() {
             </div>
           </TabsContent>
         </Tabs>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- keep Smart Memos tab visible at all times
- show placeholder messages when no deals are uploaded
- fetch a personalised memo when a deal is clicked
- expose `/api/deals/{deal_id}/memo` endpoint for memo generation
- include deal ids in upload response

## Testing
- `npm run build` *(fails: vite not found)*
- `python -m py_compile backend/app/main.py backend/db/*.py`


------
https://chatgpt.com/codex/tasks/task_e_685459f2d858832db97f2819150f15ec