### PR TITLE
Improve memo formatting

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -46,7 +46,9 @@ def extract_fields(text: str) -> dict:
         "margin": 38.0,
         "capital_sought": "$150M" if "Dynamo" in text else "TBD",
         "objective": "Growth capital / refinance / Series E",
-        "summary": text[:800],
+        # Keep the teaser overview short so the frontend display isn't too heavy
+        # A couple of sentences are usually enough for context
+        "summary": text[:400],
         "highlights": [
             "Recurring revenue",
             "Customer retention",
@@ -133,12 +135,17 @@ async def generate_memo(deal_id: int, user_id: int | None = None):
 
     prompt = PromptTemplate(
         input_variables=["summary", "investor"],
-        template="\n".join([
-            "Write a concise one-page investment memo for the following deal:",
-            "{summary}",
-            "Tailor the memo for the investor described below:",
-            "{investor}",
-        ]),
+        template="\n".join(
+            [
+                "Write a short investment memo with the following sections:",
+                "Overview (two sentences maximum),",
+                "Investor Profile,",
+                "Thesis,",
+                "Investment Recommendation.",
+                "Deal summary: {summary}",
+                "Investor info: {investor}",
+            ]
+        ),
     )
     chain = prompt | llm
     response = chain.invoke({"summary": deal.summary, "investor": investor_profile})

--- a/frontend/src/DealIntelligenceApp.tsx
+++ b/frontend/src/DealIntelligenceApp.tsx
@@ -152,7 +152,10 @@ export default function DealIntelligenceApp() {
                           <li key={i}>{h}</li>
                         ))}
                       </ul>
-                      <p><strong>AI Insights:</strong> {memo}</p>
+                      <p><strong>AI Insights:</strong></p>
+                      {memo.split('\n').map((line, i) => (
+                        line.trim() && <p key={i}>{line}</p>
+                      ))}
                       <Button
                         variant="outline"
                         onClick={() => alert('Deep research view coming soon...')}


### PR DESCRIPTION
## Summary
- condense text used for overview so memos show less bulky preview
- rework memo prompt to produce shorter overview and clearly separated sections
- render AI insights paragraphs line by line in UI

## Testing
- `python -m py_compile backend/app/main.py`
- `npm test --silent` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68545bd1f968832d99dc26238da7d312